### PR TITLE
Avoid UnicodeDecodeError exception during patches parsing

### DIFF
--- a/ConfigFile.py
+++ b/ConfigFile.py
@@ -81,6 +81,10 @@ EMMpat = re.compile(r'^([^\s]+)\s+([^<]+)\s*(<\s*(\d+-\d+-\d+)\s*)?$')
 def ReadEmailEmployers(name):
     try:
         file = open(name, 'r')
+        # We need to avoid decoding errors during the parsing and
+        # using "surrogateescape" allow for encoding methods to
+        # restore the byte if need.
+        file.reconfigure(errors="surrogateescape")
     except IOError:
         croak('Unable to open email/employer file %s' % (name))
     line = ReadConfigLine(file)

--- a/logparser.py
+++ b/logparser.py
@@ -38,6 +38,11 @@ class LogPatchSplitter:
         self.buffer = None
         self.patch = []
 
+        # We need to avoid decoding errors during the parsing of
+        # patches and using "surrogateescape" allow for encoding
+        # methods to restore the byte if need.
+        self.fd.reconfigure(errors="surrogateescape")
+
     def __iter__(self):
         return self
 


### PR DESCRIPTION
We need to avoid decoding errors during the parsing of patches and
using "surrogateescape" allow for encoding methods to restore the
byte if need.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
